### PR TITLE
Ignore user-site packages in pixi env

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,8 @@ platforms = ["linux-64"]
 [activation.env]
 # Let torchcodec find pixi's FFmpeg shared libraries at runtime.
 LD_LIBRARY_PATH = "$PIXI_PROJECT_ROOT/.pixi/envs/default/lib:$LD_LIBRARY_PATH"
+# Ignore ~/.local/lib user-site packages, which can shadow env deps (e.g. a stale typing_extensions).
+PYTHONNOUSERSITE = "1"
 
 [dependencies]
 python = "3.12.*"


### PR DESCRIPTION
A stale typing_extensions in ~/.local/lib was shadowing the pixi env's copy, breaking pydantic imports (missing Sentinel). Set PYTHONNOUSERSITE=1 in [activation.env] so env dependencies always win.