### PR TITLE
Ignore user-site packages in pixi env

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,7 @@ platforms = ["linux-64"]
 [activation.env]
 # Let torchcodec find pixi's FFmpeg shared libraries at runtime.
 LD_LIBRARY_PATH = "$PIXI_PROJECT_ROOT/.pixi/envs/default/lib:$LD_LIBRARY_PATH"
+PYTHONNOUSERSITE = "1"
 
 [dependencies]
 python = "3.12.*"


### PR DESCRIPTION
A stale `typing_extensions` in `~/.local/lib` was shadowing the pixi env's copy, breaking pydantic imports.

Set `PYTHONNOUSERSITE=1` in `[activation.env]` so environment dependencies always win over user-site packages.

Verified: `pixi run test` -> 218 passed, 17 skipped.